### PR TITLE
Update sonarwhal to webhint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM node
 
-#https://github.com/sonarwhal/sonarwhal
+#https://github.com/webhintio/hint
 
-# https://github.com/sonarwhal/sonarwhal/issues/600
+# https://github.com/webhintio/hint/issues/600
 RUN apt-get update && apt-get install -y curl apt-transport-https && \
-    npm install -g --engine-strict sonarwhal --unsafe-perm=true
+    npm install -g --engine-strict hint @hint/configuration-web-recommended @hint/configuration-progressive-web-apps --unsafe-perm=true
 
-COPY dot-sonarwhalrc /.sonarwhalrc
+COPY dot-hintrc /.hintrc
 
-ENTRYPOINT ["sonarwhal"]
+ENTRYPOINT ["hint"]
 CMD ["-h"]
 
 # docker build -t sw .

--- a/dot-hintrc
+++ b/dot-hintrc
@@ -10,7 +10,7 @@
         "codeframe"
     ],
     "ignoredUrls": [],
-    "rules": {
+    "hints": {
         "amp-validator": "off",
         "apple-touch-icons": "error",
         "axe": "error",
@@ -38,5 +38,5 @@
         "validate-set-cookie-header": "error",
         "x-content-type-options": "error"
     },
-    "rulesTimeout": 120000
+    "hintsTimeout": 120000
 }


### PR DESCRIPTION
sonarwhal was renamed to webhint. This PR updates any reference
to the new package.

Ref: https://medium.com/webhint/webhint-a-hinting-engine-for-the-web-ef0d3fa32ea9